### PR TITLE
Potential fix for Scales flickering - buoyancy/issues/64

### DIFF
--- a/js/common/model/DensityBuoyancyModel.ts
+++ b/js/common/model/DensityBuoyancyModel.ts
@@ -35,8 +35,6 @@ import TModel from '../../../../joist/js/TModel.js';
 import { PhetioObjectOptions } from '../../../../tandem/js/PhetioObject.js';
 import PickRequired from '../../../../phet-core/js/types/PickRequired.js';
 import Matrix3 from '../../../../dot/js/Matrix3.js';
-import InterpolatedProperty from './InterpolatedProperty.js';
-import Utils from '../../../../dot/js/Utils.js';
 
 // constants
 const BLOCK_SPACING = 0.01;
@@ -334,16 +332,6 @@ export default class DensityBuoyancyModel implements TModel {
               }
             }
           } );
-
-          const currentValue = mass.scaleForceInterpolatedProperty.currentValue;
-          const diff = Math.abs( currentValue - scaleForce );
-
-          // Lerping from the current value to the new value. If the difference is small, interpolate slowly
-          // This is to avoid flickering in the scale
-          scaleForce = InterpolatedProperty.interpolateNumber(
-            currentValue,
-            scaleForce,
-            Utils.clamp( Math.abs( diff ), 0.1, 1 ) );
 
           mass.scaleForceInterpolatedProperty.setNextValue( scaleForce );
         }

--- a/js/common/model/DensityBuoyancyModel.ts
+++ b/js/common/model/DensityBuoyancyModel.ts
@@ -35,6 +35,8 @@ import TModel from '../../../../joist/js/TModel.js';
 import { PhetioObjectOptions } from '../../../../tandem/js/PhetioObject.js';
 import PickRequired from '../../../../phet-core/js/types/PickRequired.js';
 import Matrix3 from '../../../../dot/js/Matrix3.js';
+import InterpolatedProperty from './InterpolatedProperty.js';
+import Utils from '../../../../dot/js/Utils.js';
 
 // constants
 const BLOCK_SPACING = 0.01;
@@ -332,6 +334,14 @@ export default class DensityBuoyancyModel implements TModel {
               }
             }
           } );
+
+          const currentValue = mass.scaleForceInterpolatedProperty.currentValue;
+          const diff = Math.abs( currentValue - scaleForce );
+          scaleForce = InterpolatedProperty.interpolateNumber(
+            currentValue,
+            scaleForce,
+            diff < 0.1 ? Utils.clamp( Math.abs( diff ), 0.1, 1 ) : 1 );
+
           mass.scaleForceInterpolatedProperty.setNextValue( scaleForce );
         }
 

--- a/js/common/model/DensityBuoyancyModel.ts
+++ b/js/common/model/DensityBuoyancyModel.ts
@@ -337,6 +337,9 @@ export default class DensityBuoyancyModel implements TModel {
 
           const currentValue = mass.scaleForceInterpolatedProperty.currentValue;
           const diff = Math.abs( currentValue - scaleForce );
+
+          // Lerping from the current value to the new value. If the difference is small, interpolate slowly
+          // This is to avoid flickering in the scale
           scaleForce = InterpolatedProperty.interpolateNumber(
             currentValue,
             scaleForce,

--- a/js/common/model/DensityBuoyancyModel.ts
+++ b/js/common/model/DensityBuoyancyModel.ts
@@ -340,7 +340,7 @@ export default class DensityBuoyancyModel implements TModel {
           scaleForce = InterpolatedProperty.interpolateNumber(
             currentValue,
             scaleForce,
-            diff < 0.1 ? Utils.clamp( Math.abs( diff ), 0.1, 1 ) : 1 );
+            Utils.clamp( Math.abs( diff ), 0.1, 1 ) );
 
           mass.scaleForceInterpolatedProperty.setNextValue( scaleForce );
         }

--- a/js/common/model/InterpolatedProperty.ts
+++ b/js/common/model/InterpolatedProperty.ts
@@ -20,6 +20,7 @@ import IOTypeCache from '../../../../tandem/js/IOTypeCache.js';
 type Interpolate<T> = ( a: T, b: T, ratio: number ) => T;
 type SelfOptions<T> = {
   interpolate: Interpolate<T>;
+  nextValueInterpolationRatio?: number;
 };
 export type InterpolatedPropertyOptions<T> = SelfOptions<T> & PropertyOptions<T>;
 
@@ -28,13 +29,15 @@ export default class InterpolatedProperty<T> extends Property<T> {
   public currentValue: T;
   public previousValue: T;
   public ratio: number;
+  public nextValueInterpolationRatio: number;
 
   private readonly interpolate: Interpolate<T>;
 
   public constructor( initialValue: T, providedOptions: InterpolatedPropertyOptions<T> ) {
 
     const options = optionize<InterpolatedPropertyOptions<T>, SelfOptions<T>, PropertyOptions<T>>()( {
-      phetioOuterType: InterpolatedProperty.InterpolatedPropertyIO
+      phetioOuterType: InterpolatedProperty.InterpolatedPropertyIO,
+      nextValueInterpolationRatio: 1 // The change is instant by default
     }, providedOptions );
 
     super( initialValue, options );
@@ -45,6 +48,7 @@ export default class InterpolatedProperty<T> extends Property<T> {
     this.previousValue = initialValue;
 
     this.ratio = 0;
+    this.nextValueInterpolationRatio = options.nextValueInterpolationRatio;
   }
 
   /**
@@ -52,7 +56,7 @@ export default class InterpolatedProperty<T> extends Property<T> {
    */
   public setNextValue( value: T ): void {
     this.previousValue = this.currentValue;
-    this.currentValue = value;
+    this.currentValue = this.interpolate( this.previousValue, value, this.nextValueInterpolationRatio );
   }
 
   /**

--- a/js/common/model/Scale.ts
+++ b/js/common/model/Scale.ts
@@ -114,6 +114,7 @@ export default class Scale extends Mass {
 
     this.scaleForceInterpolatedProperty = new InterpolatedProperty( 0, {
       interpolate: InterpolatedProperty.interpolateNumber,
+      nextValueInterpolationRatio: 0.1, // To avoid flickering in the readout
       phetioValueType: NumberIO,
       tandem: options.tandem.createTandem( 'scaleForceInterpolatedProperty' ),
       units: 'N',


### PR DESCRIPTION
We discussed in https://github.com/phetsims/density-buoyancy-common/issues/130 and in Slack. KP wants to keep scales movable, specially pool scales.

The following fix computes the difference between the current and previous value of the scale readout and interpolates the new value with respect to that difference. If it's bigger than 1, it's an instant change (same as it was before), but as it gets smaller, the interpolation smooths out the resulting value.

**My experiment:** On Buoyancy Explore screen test the default block, then aluminum block, then max out the aluminum block's volume. In the current state of the sim, the flickering is very noticeable. With this fix, it disappears on the land scale, and it's very subtle in the pool scale.

Another way to trigger flickering was forcing the block into the scale. With this solution that's also gone.

Please review and merge or suggest changes. Happy weekend :)

Edit: This is potential fix for https://github.com/phetsims/buoyancy/issues/64